### PR TITLE
Add support for RGB messages

### DIFF
--- a/plugin/src/main/java/com/eintosti/buildsystem/BuildSystem.java
+++ b/plugin/src/main/java/com/eintosti/buildsystem/BuildSystem.java
@@ -17,6 +17,7 @@ import com.eintosti.buildsystem.object.settings.Settings;
 import com.eintosti.buildsystem.tabcomplete.*;
 import com.eintosti.buildsystem.util.ConfigValues;
 import com.eintosti.buildsystem.util.Messages;
+import com.eintosti.buildsystem.util.RBGUtils;
 import com.eintosti.buildsystem.util.SkullCache;
 import com.eintosti.buildsystem.util.external.UpdateChecker;
 import com.eintosti.buildsystem.version.CustomBlocks;
@@ -385,7 +386,7 @@ public class BuildSystem extends JavaPlugin {
         String prefix = Messages.getInstance().messageData.get("prefix");
         try {
             final String defaultPrefix = "§8× §bBuildSystem §8┃";
-            return prefix != null ? ChatColor.translateAlternateColorCodes('&', prefix) : defaultPrefix;
+            return prefix != null ? ChatColor.translateAlternateColorCodes('&', RBGUtils.color(prefix)) : defaultPrefix;
         } catch (NullPointerException e) {
             Messages.getInstance().createMessageFile();
             return getPrefixString();
@@ -394,7 +395,8 @@ public class BuildSystem extends JavaPlugin {
 
     public String getString(String key) {
         try {
-            return ChatColor.translateAlternateColorCodes('&', Messages.getInstance().messageData.get(key).replace("%prefix%", getPrefixString()));
+            String message = Messages.getInstance().messageData.get(key).replace("%prefix%", getPrefixString());
+            return ChatColor.translateAlternateColorCodes('&', RBGUtils.color(message));
         } catch (NullPointerException e) {
             Bukkit.getConsoleSender().sendMessage(ChatColor.RED + "[BuildSystem] Could not find message with key: " + key);
             Messages.getInstance().createMessageFile();
@@ -408,7 +410,8 @@ public class BuildSystem extends JavaPlugin {
             String string = Messages.getInstance().messageData.get(key);
             String[] splitString = string.substring(1, string.length() - 1).split(", ");
             for (String s : splitString) {
-                list.add(ChatColor.translateAlternateColorCodes('&', s.replace("%prefix%", getPrefixString())));
+                String message = s.replace("%prefix%", getPrefixString());
+                list.add(ChatColor.translateAlternateColorCodes('&', RBGUtils.color(message)));
             }
             return list;
         } catch (NullPointerException e) {

--- a/plugin/src/main/java/com/eintosti/buildsystem/listener/AsyncPlayerChatListener.java
+++ b/plugin/src/main/java/com/eintosti/buildsystem/listener/AsyncPlayerChatListener.java
@@ -9,6 +9,7 @@
 package com.eintosti.buildsystem.listener;
 
 import com.eintosti.buildsystem.BuildSystem;
+import com.eintosti.buildsystem.util.RBGUtils;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -31,6 +32,7 @@ public class AsyncPlayerChatListener implements Listener {
             return;
         }
 
-        event.setMessage(ChatColor.translateAlternateColorCodes('&', event.getMessage()));
+        String coloredMessage = ChatColor.translateAlternateColorCodes('&', RBGUtils.color(event.getMessage()));
+        event.setMessage(coloredMessage);
     }
 }

--- a/plugin/src/main/java/com/eintosti/buildsystem/listener/SignChangeListener.java
+++ b/plugin/src/main/java/com/eintosti/buildsystem/listener/SignChangeListener.java
@@ -9,6 +9,7 @@
 package com.eintosti.buildsystem.listener;
 
 import com.eintosti.buildsystem.BuildSystem;
+import com.eintosti.buildsystem.util.RBGUtils;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -34,7 +35,8 @@ public class SignChangeListener implements Listener {
         for (int i = 0; i < event.getLines().length; i++) {
             String line = event.getLine(i);
             if (line != null) {
-                event.setLine(i, ChatColor.translateAlternateColorCodes('&', line));
+                String coloredLine = ChatColor.translateAlternateColorCodes('&', RBGUtils.color(line));
+                event.setLine(i, coloredLine);
             }
         }
     }

--- a/plugin/src/main/java/com/eintosti/buildsystem/util/RBGUtils.java
+++ b/plugin/src/main/java/com/eintosti/buildsystem/util/RBGUtils.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2022, Thomas Meaney
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.eintosti.buildsystem.util;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * @author CoasterFreakDE (Original Author)
+ * @author einTosti (Ported to Java)
+ */
+public class RBGUtils {
+
+    private static final Pattern DEFAULT_HEX = Pattern.compile("#[0-9a-fA-F]{6}");
+    private static final Pattern BRACKET_HEX = Pattern.compile("\\{#[0-9a-fA-F]{6}}");
+    private static final Pattern SPIGOT_HEX = Pattern.compile("&x[&0-9a-fA-F]{12}");
+
+    private static String toChatColor(String hexCode) {
+        StringBuilder magic = new StringBuilder("§x");
+        char[] colorChars = hexCode.substring(1).toCharArray();
+
+        for (char c : colorChars) {
+            magic.append('§').append(c);
+        }
+
+        return magic.toString();
+    }
+
+    public static String color(String input) {
+        String text = applyFormats(input);
+
+        Matcher matcher = DEFAULT_HEX.matcher(text);
+        while (matcher.find()) {
+            String hexCode = matcher.group();
+            text = text.replace(hexCode, toChatColor(hexCode));
+        }
+
+        return text;
+    }
+
+    private static String applyFormats(String input) {
+        String text = input;
+
+        text = parseFormat1(text);
+        text = parseFormat2(text);
+        text = parseFormat3(text);
+
+        return text;
+    }
+
+    //&#RRGGBB
+    private static String parseFormat1(String input) {
+        return input.replace("&#", "#");
+    }
+
+    //{#RRGGBB}
+    private static String parseFormat2(String input) {
+        String text = input;
+        Matcher matcher = BRACKET_HEX.matcher(text);
+
+        while (matcher.find()) {
+            String hexCode = matcher.group();
+            String fixed = hexCode.substring(2, 8);
+            text = text.replace(hexCode, "#" + fixed);
+        }
+
+        return text;
+    }
+
+    //&x&R&R&G&G&B&B
+    private static String parseFormat3(String input) {
+        String text = input.replace('\u00a7', '&');
+
+        Matcher matcher = SPIGOT_HEX.matcher(text);
+        while (matcher.find()) {
+            String hexCode = matcher.group();
+            String fixed = hexCode.substring(3).replace("&", "");
+            text = text.replace(hexCode, "#" + fixed);
+        }
+
+        return text;
+    }
+}

--- a/plugin/src/main/java/com/eintosti/buildsystem/util/RBGUtils.java
+++ b/plugin/src/main/java/com/eintosti/buildsystem/util/RBGUtils.java
@@ -47,20 +47,20 @@ public class RBGUtils {
     private static String applyFormats(String input) {
         String text = input;
 
-        text = parseFormat1(text);
-        text = parseFormat2(text);
-        text = parseFormat3(text);
+        text = parseDefaultFormat(text);
+        text = parseBracketFormat(text);
+        text = parseSpigotFormat(text);
 
         return text;
     }
 
     //&#RRGGBB
-    private static String parseFormat1(String input) {
+    private static String parseDefaultFormat(String input) {
         return input.replace("&#", "#");
     }
 
     //{#RRGGBB}
-    private static String parseFormat2(String input) {
+    private static String parseBracketFormat(String input) {
         String text = input;
         Matcher matcher = BRACKET_HEX.matcher(text);
 
@@ -74,8 +74,8 @@ public class RBGUtils {
     }
 
     //&x&R&R&G&G&B&B
-    private static String parseFormat3(String input) {
-        String text = input.replace('\u00a7', '&');
+    private static String parseSpigotFormat(String input) {
+        String text = input.replace('§', '&');
 
         Matcher matcher = SPIGOT_HEX.matcher(text);
         while (matcher.find()) {

--- a/plugin/src/main/resources/plugin.yml
+++ b/plugin/src/main/resources/plugin.yml
@@ -4,7 +4,7 @@ api-version: "1.13"
 author: einTosti
 main: com.eintosti.buildsystem.BuildSystem
 description: Powerful, easy to use system for builders
-softdepend: [ PlaceholderAPI ]
+softdepend: [ PlaceholderAPI, WorldEdit ]
 
 commands:
   back:


### PR DESCRIPTION
Fixes #47 

- Requires Minecraft Java 1.16+
- Supported patterns: `#RRGGBB`, `&#RRGGBB`, `{#RRGGBB}`, `&x&r&r&g&g&b&b`