### PR TITLE
Implement `buildsystem:role` Context for LuckPerms

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -57,30 +57,32 @@
             <version>1.5.21</version>
             <scope>provided</scope>
         </dependency>
-        <!-- PlaceholderAPI -->
-        <dependency>
-            <groupId>me.clip</groupId>
-            <artifactId>placeholderapi</artifactId>
-            <version>2.11.1</version>
-            <scope>provided</scope>
-        </dependency>
         <!-- XSeries -->
         <dependency>
             <groupId>com.github.cryptomorin</groupId>
             <artifactId>XSeries</artifactId>
             <version>8.6.0.0.1</version>
+            <scope>compile</scope>
         </dependency>
         <!-- FastBoard -->
         <dependency>
             <groupId>fr.mrmicky</groupId>
             <artifactId>fastboard</artifactId>
             <version>1.2.1</version>
+            <scope>compile</scope>
         </dependency>
-        <!-- Adventure Text -->
+        <!-- LuckPerms -->
         <dependency>
-            <groupId>net.kyori</groupId>
-            <artifactId>adventure-text-minimessage</artifactId>
-            <version>4.1.0-SNAPSHOT</version>
+            <groupId>net.luckperms</groupId>
+            <artifactId>api</artifactId>
+            <version>5.3</version>
+            <scope>provided</scope>
+        </dependency>
+        <!-- PlaceholderAPI -->
+        <dependency>
+            <groupId>me.clip</groupId>
+            <artifactId>placeholderapi</artifactId>
+            <version>2.11.1</version>
             <scope>provided</scope>
         </dependency>
         <!-- FAWE Core -->

--- a/plugin/src/main/java/com/eintosti/buildsystem/command/WorldsCommand.java
+++ b/plugin/src/main/java/com/eintosti/buildsystem/command/WorldsCommand.java
@@ -286,7 +286,6 @@ public class WorldsCommand implements CommandExecutor {
             }
 
             case "info": {
-                //TODO: Print information about the custom generator?
                 if (!player.hasPermission("buildsystem.info")) {
                     plugin.sendPermissionMessage(player);
                     return true;
@@ -632,6 +631,7 @@ public class WorldsCommand implements CommandExecutor {
         return commandComponent;
     }
 
+    //TODO: Print information about the custom generator?
     private void sendInfoMessage(Player player, BuildWorld buildWorld) {
         List<String> infoMessage = new ArrayList<>();
         for (String line : plugin.getStringList("world_info")) {
@@ -654,7 +654,6 @@ public class WorldsCommand implements CommandExecutor {
                     .replace("%physics%", String.valueOf(buildWorld.isPhysics()))
                     .replace("%explosions%", String.valueOf(buildWorld.isExplosions()))
                     .replace("%mobai%", String.valueOf(buildWorld.isMobAI()))
-                    .replace("%customspawn%", getCustomSpawn(buildWorld))
                     .replace("%custom_spawn%", getCustomSpawn(buildWorld));
             infoMessage.add(replace);
         }

--- a/plugin/src/main/java/com/eintosti/buildsystem/expansion/luckperms/LuckPermsExpansion.java
+++ b/plugin/src/main/java/com/eintosti/buildsystem/expansion/luckperms/LuckPermsExpansion.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2022, Thomas Meaney
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.eintosti.buildsystem.expansion.luckperms;
+
+import com.eintosti.buildsystem.BuildSystem;
+import net.luckperms.api.LuckPerms;
+import net.luckperms.api.context.ContextCalculator;
+import net.luckperms.api.context.ContextManager;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.logging.Level;
+
+/**
+ * @author einTosti
+ */
+public class LuckPermsExpansion {
+
+    private final BuildSystem plugin;
+    private final ContextManager contextManager;
+    private final List<ContextCalculator<Player>> registeredCalculators;
+
+    public LuckPermsExpansion(BuildSystem plugin) {
+        LuckPerms luckPerms = plugin.getServer().getServicesManager().load(LuckPerms.class);
+        if (luckPerms == null) {
+            throw new IllegalStateException("LuckPerms API not loaded.");
+        }
+
+        this.plugin = plugin;
+        this.contextManager = luckPerms.getContextManager();
+        this.registeredCalculators = new ArrayList<>();
+    }
+
+    public void registerAll() {
+        register("role", () -> new RoleCalculator(plugin));
+    }
+
+    private void register(String option, Supplier<ContextCalculator<Player>> calculatorSupplier) {
+        plugin.getLogger().log(Level.INFO, "Registering '" + option + "' calculator");
+        ContextCalculator<Player> calculator = calculatorSupplier.get();
+        this.contextManager.registerCalculator(calculator);
+        this.registeredCalculators.add(calculator);
+    }
+
+    public void unregisterAll() {
+        this.registeredCalculators.forEach(this.contextManager::unregisterCalculator);
+        this.registeredCalculators.clear();
+    }
+}

--- a/plugin/src/main/java/com/eintosti/buildsystem/expansion/luckperms/RoleCalculator.java
+++ b/plugin/src/main/java/com/eintosti/buildsystem/expansion/luckperms/RoleCalculator.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2022, Thomas Meaney
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.eintosti.buildsystem.expansion.luckperms;
+
+import com.eintosti.buildsystem.BuildSystem;
+import com.eintosti.buildsystem.manager.WorldManager;
+import com.eintosti.buildsystem.object.world.BuildWorld;
+import net.luckperms.api.context.ContextCalculator;
+import net.luckperms.api.context.ContextConsumer;
+import net.luckperms.api.context.ContextSet;
+import net.luckperms.api.context.ImmutableContextSet;
+import org.bukkit.entity.Player;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+import java.util.UUID;
+
+/**
+ * @author einTosti
+ */
+public class RoleCalculator implements ContextCalculator<Player> {
+
+    private static final String KEY = "buildsystem:role";
+
+    private final WorldManager worldManager;
+
+    public RoleCalculator(BuildSystem plugin) {
+        this.worldManager = plugin.getWorldManager();
+    }
+
+    @Override
+    public void calculate(@NonNull Player player, @NonNull ContextConsumer contextConsumer) {
+        BuildWorld buildWorld = worldManager.getBuildWorld(player.getWorld());
+        contextConsumer.accept(KEY, Role.matchRole(player, buildWorld).toString());
+    }
+
+    @Override
+    public ContextSet estimatePotentialContexts() {
+        ImmutableContextSet.Builder builder = ImmutableContextSet.builder();
+        for (Role role : Role.values()) {
+            builder.add(KEY, role.toString());
+        }
+        return builder.build();
+    }
+
+    private enum Role {
+        CREATOR,
+        BUILDER,
+        GUEST;
+
+        public static Role matchRole(Player player, BuildWorld buildWorld) {
+            if (buildWorld == null) {
+                return GUEST;
+            }
+
+            UUID playerUuid = player.getUniqueId();
+            if (buildWorld.getCreatorId().equals(playerUuid)) {
+                return CREATOR;
+            } else if (buildWorld.isBuilder(playerUuid)) {
+                return BUILDER;
+            } else {
+                return GUEST;
+            }
+        }
+
+        @Override
+        public String toString() {
+            return this.name().toLowerCase();
+        }
+    }
+}

--- a/plugin/src/main/java/com/eintosti/buildsystem/expansion/placeholderapi/PlaceholderApiExpansion.java
+++ b/plugin/src/main/java/com/eintosti/buildsystem/expansion/placeholderapi/PlaceholderApiExpansion.java
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-package com.eintosti.buildsystem.expansion;
+package com.eintosti.buildsystem.expansion.placeholderapi;
 
 import com.eintosti.buildsystem.BuildSystem;
 import com.eintosti.buildsystem.manager.SettingsManager;
@@ -21,7 +21,7 @@ import org.jetbrains.annotations.Nullable;
 /**
  * @author einTosti
  */
-public class BuildSystemExpansion extends PlaceholderExpansion {
+public class PlaceholderApiExpansion extends PlaceholderExpansion {
 
     private static final String SETTINGS_KEY = "settings";
 
@@ -29,7 +29,7 @@ public class BuildSystemExpansion extends PlaceholderExpansion {
     private final SettingsManager settingsManager;
     private final WorldManager worldManager;
 
-    public BuildSystemExpansion(BuildSystem plugin) {
+    public PlaceholderApiExpansion(BuildSystem plugin) {
         this.plugin = plugin;
         this.settingsManager = plugin.getSettingsManager();
         this.worldManager = plugin.getWorldManager();
@@ -169,7 +169,7 @@ public class BuildSystemExpansion extends PlaceholderExpansion {
 
     /**
      * This is the method called when a placeholder with the identifier needed for
-     * {@link BuildSystemExpansion#parseSettingsPlaceholder(Player, String)} is not found
+     * {@link PlaceholderApiExpansion#parseSettingsPlaceholder(Player, String)} is not found
      * <p>
      * The default layout for a world placeholder is {@code %buildsystem_<value>%}.
      * If a world is not specified by using the format {@code %buildsystem_<value>_<world>%}

--- a/plugin/src/main/java/com/eintosti/buildsystem/inventory/BuilderInventory.java
+++ b/plugin/src/main/java/com/eintosti/buildsystem/inventory/BuilderInventory.java
@@ -27,6 +27,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 
 import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 /**
@@ -78,7 +79,7 @@ public class BuilderInventory extends PaginatedInventory implements Listener {
     }
 
     private void addItems(BuildWorld buildWorld, Player player) {
-        ArrayList<Builder> builders = buildWorld.getBuilders();
+        List<Builder> builders = buildWorld.getBuilders();
         this.numBuilders = builders.size();
         int numInventories = (numBuilders % MAX_BUILDERS == 0 ? numBuilders : numBuilders + 1) != 0 ? (numBuilders % MAX_BUILDERS == 0 ? numBuilders : numBuilders + 1) : 1;
 

--- a/plugin/src/main/java/com/eintosti/buildsystem/manager/WorldManager.java
+++ b/plugin/src/main/java/com/eintosti/buildsystem/manager/WorldManager.java
@@ -80,6 +80,10 @@ public class WorldManager {
                 .orElse(null);
     }
 
+    public BuildWorld getBuildWorld(World world) {
+        return getBuildWorld(world.getName());
+    }
+
     public List<BuildWorld> getBuildWorlds() {
         return buildWorlds;
     }

--- a/plugin/src/main/java/com/eintosti/buildsystem/object/world/BuildWorld.java
+++ b/plugin/src/main/java/com/eintosti/buildsystem/object/world/BuildWorld.java
@@ -30,6 +30,7 @@ import org.jetbrains.annotations.NotNull;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
@@ -47,14 +48,15 @@ public class BuildWorld implements ConfigurationSerializable {
     private String creator;
     private UUID creatorId;
     private final WorldType worldType;
+    private final List<Builder> builders;
+    private final long creationDate;
+
     private XMaterial material;
     private boolean privateWorld;
     private WorldStatus worldStatus;
     private String project;
     private String permission;
     private String customSpawn;
-    private final ArrayList<Builder> builders;
-    private final long date;
 
     private final String chunkGeneratorString;
     private ChunkGenerator chunkGenerator;
@@ -71,7 +73,16 @@ public class BuildWorld implements ConfigurationSerializable {
     private boolean loaded;
     private BukkitTask unloadTask;
 
-    public BuildWorld(BuildSystem plugin, String name, String creator, UUID creatorId, WorldType worldType, long date, boolean privateWorld, String... chunkGeneratorString) {
+    public BuildWorld(
+            BuildSystem plugin,
+            String name,
+            String creator,
+            UUID creatorId,
+            WorldType worldType,
+            long creationDate,
+            boolean privateWorld,
+            String... chunkGeneratorString
+    ) {
         this.plugin = plugin;
         this.configValues = plugin.getConfigValues();
 
@@ -85,7 +96,7 @@ public class BuildWorld implements ConfigurationSerializable {
         this.permission = "-";
         this.customSpawn = null;
         this.builders = new ArrayList<>();
-        this.date = date;
+        this.creationDate = creationDate;
 
         this.physics = configValues.isWorldPhysics();
         this.explosions = configValues.isWorldExplosions();
@@ -154,7 +165,7 @@ public class BuildWorld implements ConfigurationSerializable {
             WorldStatus worldStatus,
             String project,
             String permission,
-            long date,
+            long creationDate,
             boolean physics,
             boolean explosions,
             boolean mobAI,
@@ -179,7 +190,7 @@ public class BuildWorld implements ConfigurationSerializable {
         this.worldStatus = worldStatus;
         this.project = project;
         this.permission = permission;
-        this.date = date;
+        this.creationDate = creationDate;
         this.physics = physics;
         this.explosions = explosions;
         this.mobAI = mobAI;
@@ -358,14 +369,14 @@ public class BuildWorld implements ConfigurationSerializable {
      * @return The amount of milliseconds that have passed since `January 1, 1970 UTC`, until the world was created
      */
     public long getCreationDate() {
-        return date;
+        return creationDate;
     }
 
     /**
      * @return The creation date in the format provided by the config
      */
     public String getFormattedCreationDate() {
-        return date > 0 ? new SimpleDateFormat(configValues.getDateFormat()).format(date) : "-";
+        return creationDate > 0 ? new SimpleDateFormat(configValues.getDateFormat()).format(creationDate) : "-";
     }
 
     /**
@@ -474,7 +485,7 @@ public class BuildWorld implements ConfigurationSerializable {
     /**
      * @return List of all {@link Builder}s
      */
-    public ArrayList<Builder> getBuilders() {
+    public List<Builder> getBuilders() {
         return builders;
     }
 

--- a/plugin/src/main/resources/plugin.yml
+++ b/plugin/src/main/resources/plugin.yml
@@ -4,7 +4,7 @@ api-version: "1.13"
 author: einTosti
 main: com.eintosti.buildsystem.BuildSystem
 description: Powerful, easy to use system for builders
-softdepend: [ PlaceholderAPI, WorldEdit ]
+softdepend: [ LuckPerms, PlaceholderAPI, WorldEdit ]
 
 commands:
   back:


### PR DESCRIPTION
Implements #56 

Introduces the `buildsystem:role` Context (requires LuckPerms).
Can have the following values:
- `creator`
- `builder`
- `guest`

**For example:** You want players who are guests in a world (neither _creator_ nor _builder_) to remain in the gamemode they currently are in.

Now you can use the following `Context`:
`/lp user <user> permission set buildsystem.gamemode false buildsystem:role=guest`