### PR TITLE
Add limits to the amount of worlds allowed to be created

### DIFF
--- a/buildsystem-core/src/main/java/com/eintosti/buildsystem/expansion/luckperms/RoleCalculator.java
+++ b/buildsystem-core/src/main/java/com/eintosti/buildsystem/expansion/luckperms/RoleCalculator.java
@@ -59,7 +59,9 @@ public class RoleCalculator implements ContextCalculator<Player> {
             }
 
             UUID playerUuid = player.getUniqueId();
-            if (buildWorld.getCreatorId().equals(playerUuid)) {
+            UUID creatorUuid = buildWorld.getCreatorId();
+
+            if (creatorUuid != null && creatorUuid.equals(playerUuid)) {
                 return CREATOR;
             } else if (buildWorld.isBuilder(playerUuid)) {
                 return BUILDER;

--- a/buildsystem-core/src/main/java/com/eintosti/buildsystem/inventory/CreateInventory.java
+++ b/buildsystem-core/src/main/java/com/eintosti/buildsystem/inventory/CreateInventory.java
@@ -37,6 +37,7 @@ public class CreateInventory extends PaginatedInventory implements Listener {
     private final WorldManager worldManager;
 
     private int numTemplates = 0;
+    private boolean createPrivateWorld;
 
     public CreateInventory(BuildSystem plugin) {
         this.plugin = plugin;
@@ -72,7 +73,9 @@ public class CreateInventory extends PaginatedInventory implements Listener {
         return inventory;
     }
 
-    public void openInventory(Player player, Page page) {
+    public void openInventory(Player player, Page page, boolean createPrivateWorld) {
+        this.createPrivateWorld = createPrivateWorld;
+
         if (page == Page.TEMPLATES) {
             addTemplates(player, page);
             player.openInventory(inventories[getInvIndex(player)]);
@@ -162,7 +165,6 @@ public class CreateInventory extends PaginatedInventory implements Listener {
         }
 
         Player player = (Player) event.getWhoClicked();
-        boolean privateWorld = worldManager.createPrivateWorldPlayers.contains(player);
         CreateInventory.Page newPage = null;
 
         switch (event.getSlot()) {
@@ -178,10 +180,7 @@ public class CreateInventory extends PaginatedInventory implements Listener {
         }
 
         if (newPage != null) {
-            openInventory(player, newPage);
-            if (privateWorld) {
-                worldManager.createPrivateWorldPlayers.add(player);
-            }
+            openInventory(player, newPage, this.createPrivateWorld);
             XSound.ENTITY_CHICKEN_EGG.play(player);
             return;
         }
@@ -192,7 +191,6 @@ public class CreateInventory extends PaginatedInventory implements Listener {
         }
 
         int slot = event.getSlot();
-        boolean createPrivateWorld = worldManager.createPrivateWorldPlayers.contains(player);
 
         switch (Page.getCurrentPage(inventory)) {
             case PREDEFINED: {
@@ -248,7 +246,7 @@ public class CreateInventory extends PaginatedInventory implements Listener {
                         } else if (slot == 42) {
                             incrementInv(player);
                         }
-                        openInventory(player, CreateInventory.Page.TEMPLATES);
+                        openInventory(player, CreateInventory.Page.TEMPLATES, createPrivateWorld);
                         break;
                     default:
                         return;

--- a/buildsystem-core/src/main/java/com/eintosti/buildsystem/inventory/DeleteInventory.java
+++ b/buildsystem-core/src/main/java/com/eintosti/buildsystem/inventory/DeleteInventory.java
@@ -14,6 +14,7 @@ import com.eintosti.buildsystem.BuildSystem;
 import com.eintosti.buildsystem.manager.InventoryManager;
 import com.eintosti.buildsystem.object.world.BuildWorld;
 import org.bukkit.Bukkit;
+import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -34,24 +35,34 @@ public class DeleteInventory implements Listener {
         plugin.getServer().getPluginManager().registerEvents(this, plugin);
     }
 
-    private Inventory getInventory(Player player, BuildWorld buildWorld) {
-        Inventory inventory = Bukkit.createInventory(null, 45, plugin.getString("delete_title"));
-        fillGuiWithGlass(player, inventory);
+    private Inventory getInventory(BuildWorld buildWorld) {
+        Inventory inventory = Bukkit.createInventory(null, 27, plugin.getString("delete_title"));
+        fillGuiWithGlass(inventory);
 
+        inventoryManager.addItemStack(inventory, 11, XMaterial.LIME_DYE, plugin.getString("delete_world_confirm"));
         inventoryManager.addItemStack(inventory, 13, XMaterial.FILLED_MAP, plugin.getString("delete_world_name").replace("%world%", buildWorld.getName()), plugin.getStringList("delete_world_name_lore"));
-        inventoryManager.addItemStack(inventory, 29, XMaterial.RED_DYE, plugin.getString("delete_world_cancel"));
-        inventoryManager.addItemStack(inventory, 33, XMaterial.LIME_DYE, plugin.getString("delete_world_confirm"));
+        inventoryManager.addItemStack(inventory, 15, XMaterial.RED_DYE, plugin.getString("delete_world_cancel"));
 
         return inventory;
     }
 
     public void openInventory(Player player, BuildWorld buildWorld) {
-        player.openInventory(getInventory(player, buildWorld));
+        player.openInventory(getInventory(buildWorld));
     }
 
-    private void fillGuiWithGlass(Player player, Inventory inventory) {
-        for (int i = 0; i <= 44; i++) {
-            inventoryManager.addGlassPane(plugin, player, inventory, i);
+    private void fillGuiWithGlass(Inventory inventory) {
+        final int[] greenSlots = new int[]{0, 1, 2, 3, 9, 10, 12, 18, 19, 20, 21};
+        final int[] blackSlots = new int[]{4, 22};
+        final int[] redSlots = new int[]{5, 6, 7, 8, 14, 16, 17, 23, 24, 25, 26};
+
+        for (int slot : greenSlots) {
+            inventoryManager.addItemStack(inventory, slot, XMaterial.GREEN_STAINED_GLASS_PANE, "§f");
+        }
+        for (int slot : blackSlots) {
+            inventoryManager.addItemStack(inventory, slot, XMaterial.BLACK_STAINED_GLASS_PANE, "§f");
+        }
+        for (int slot : redSlots) {
+            inventoryManager.addItemStack(inventory, slot, XMaterial.RED_STAINED_GLASS_PANE, "§f");
         }
     }
 
@@ -70,13 +81,13 @@ public class DeleteInventory implements Listener {
         }
 
         switch (event.getSlot()) {
-            case 29:
-                XSound.ENTITY_ZOMBIE_BREAK_WOODEN_DOOR.play(player);
-                player.sendMessage(plugin.getString("worlds_delete_canceled").replace("%world%", buildWorld.getName()));
-                break;
-            case 33:
+            case 11:
                 XSound.ENTITY_PLAYER_LEVELUP.play(player);
                 plugin.getWorldManager().deleteWorld(player, buildWorld);
+                break;
+            case 15:
+                XSound.ENTITY_ZOMBIE_BREAK_WOODEN_DOOR.play(player);
+                player.sendMessage(plugin.getString("worlds_delete_canceled").replace("%world%", buildWorld.getName()));
                 break;
             default:
                 return;

--- a/buildsystem-core/src/main/java/com/eintosti/buildsystem/inventory/FilteredWorldsInventory.java
+++ b/buildsystem-core/src/main/java/com/eintosti/buildsystem/inventory/FilteredWorldsInventory.java
@@ -12,11 +12,9 @@ import com.cryptomorin.xseries.XMaterial;
 import com.cryptomorin.xseries.XSound;
 import com.eintosti.buildsystem.BuildSystem;
 import com.eintosti.buildsystem.manager.InventoryManager;
-import com.eintosti.buildsystem.manager.PlayerManager;
 import com.eintosti.buildsystem.manager.WorldManager;
 import com.eintosti.buildsystem.object.world.BuildWorld;
 import com.eintosti.buildsystem.object.world.WorldStatus;
-import com.eintosti.buildsystem.util.ConfigValues;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
@@ -36,9 +34,7 @@ public class FilteredWorldsInventory extends PaginatedInventory implements Liste
     private static final int MAX_WORLDS = 36;
 
     private final BuildSystem plugin;
-    private final ConfigValues configValues;
     private final InventoryManager inventoryManager;
-    private final PlayerManager playerManager;
     private final WorldManager worldManager;
 
     private final String inventoryName;
@@ -48,9 +44,7 @@ public class FilteredWorldsInventory extends PaginatedInventory implements Liste
 
     public FilteredWorldsInventory(BuildSystem plugin, String inventoryName, String noWorldsText, boolean showPrivateWorlds, Set<WorldStatus> validStatus) {
         this.plugin = plugin;
-        this.configValues = plugin.getConfigValues();
         this.inventoryManager = plugin.getInventoryManager();
-        this.playerManager = plugin.getPlayerManager();
         this.worldManager = plugin.getWorldManager();
 
         this.inventoryName = inventoryName;
@@ -80,31 +74,6 @@ public class FilteredWorldsInventory extends PaginatedInventory implements Liste
         return (int) worldManager.getBuildWorlds().stream()
                 .filter(buildWorld -> isValidWorld(player, buildWorld))
                 .count();
-    }
-
-    /**
-     * Gets whether the given player is allowed to create a new {@link BuildWorld}.<br>
-     * This depends on the following factors:
-     * <ul>
-     *  <li>Is the maximum amount of worlds set by the config less than the amount of existing worlds?</li>
-     *  <li>Is the maximum amount of worlds created by the player less than the amount of worlds said player is allowed to create?</li>
-     * <ul>
-     *
-     * @param player The player trying to create a world
-     * @return {@code true} if the player is allowed to create a world, otherwise {@code false}
-     */
-    protected boolean canCreateWorld(Player player) {
-        int maxWorldAmountConfig = configValues.getMaxWorldAmount(showPrivateWorlds);
-        if (maxWorldAmountConfig > 0 && worldManager.getBuildWorlds().size() >= maxWorldAmountConfig) {
-            return false;
-        }
-
-        int maxWorldAmountPlayer = playerManager.getMaxWorlds(player, showPrivateWorlds);
-        if (maxWorldAmountPlayer > 0 && worldManager.getBuildWorldsCreatedByPlayer(player, showPrivateWorlds).size() >= maxWorldAmountPlayer) {
-            return false;
-        }
-
-        return true;
     }
 
     public void openInventory(Player player) {
@@ -184,7 +153,7 @@ public class FilteredWorldsInventory extends PaginatedInventory implements Liste
                     return;
                 case 49:
                     XSound.ENTITY_CHICKEN_EGG.play(player);
-                    plugin.getCreateInventory().openInventory(player, CreateInventory.Page.PREDEFINED);
+                    plugin.getCreateInventory().openInventory(player, CreateInventory.Page.PREDEFINED, showPrivateWorlds);
                     return;
                 case 53:
                     incrementInv(player);

--- a/buildsystem-core/src/main/java/com/eintosti/buildsystem/inventory/PrivateInventory.java
+++ b/buildsystem-core/src/main/java/com/eintosti/buildsystem/inventory/PrivateInventory.java
@@ -49,7 +49,7 @@ public class PrivateInventory extends FilteredWorldsInventory implements Listene
 
     private void addWorldCreateItem(Inventory inventory, Player player) {
         BuildWorld buildWorld = worldManager.getBuildWorld(player.getName());
-        if (buildWorld != null || !player.hasPermission("buildsystem.createprivate")) {
+        if (buildWorld != null || !player.hasPermission("buildsystem.create.private")) {
             inventoryManager.addGlassPane(plugin, player, inventory, 49);
             return;
         }

--- a/buildsystem-core/src/main/java/com/eintosti/buildsystem/inventory/PrivateInventory.java
+++ b/buildsystem-core/src/main/java/com/eintosti/buildsystem/inventory/PrivateInventory.java
@@ -10,6 +10,7 @@ package com.eintosti.buildsystem.inventory;
 
 import com.eintosti.buildsystem.BuildSystem;
 import com.eintosti.buildsystem.manager.InventoryManager;
+import com.eintosti.buildsystem.manager.PlayerManager;
 import com.eintosti.buildsystem.manager.WorldManager;
 import com.eintosti.buildsystem.object.world.BuildWorld;
 import com.eintosti.buildsystem.object.world.WorldStatus;
@@ -25,6 +26,7 @@ public class PrivateInventory extends FilteredWorldsInventory implements Listene
 
     private final BuildSystem plugin;
     private final InventoryManager inventoryManager;
+    private final PlayerManager playerManager;
     private final WorldManager worldManager;
 
     public PrivateInventory(BuildSystem plugin) {
@@ -33,6 +35,7 @@ public class PrivateInventory extends FilteredWorldsInventory implements Listene
 
         this.plugin = plugin;
         this.inventoryManager = plugin.getInventoryManager();
+        this.playerManager = plugin.getPlayerManager();
         this.worldManager = plugin.getWorldManager();
 
         plugin.getServer().getPluginManager().registerEvents(this, plugin);
@@ -41,7 +44,7 @@ public class PrivateInventory extends FilteredWorldsInventory implements Listene
     @Override
     protected Inventory createInventory(Player player) {
         Inventory inventory = super.createInventory(player);
-        if (super.canCreateWorld(player)) {
+        if (playerManager.canCreateWorld(player, true)) {
             addWorldCreateItem(inventory, player);
         }
         return inventory;

--- a/buildsystem-core/src/main/java/com/eintosti/buildsystem/inventory/WorldsInventory.java
+++ b/buildsystem-core/src/main/java/com/eintosti/buildsystem/inventory/WorldsInventory.java
@@ -10,6 +10,7 @@ package com.eintosti.buildsystem.inventory;
 
 import com.eintosti.buildsystem.BuildSystem;
 import com.eintosti.buildsystem.manager.InventoryManager;
+import com.eintosti.buildsystem.manager.PlayerManager;
 import com.eintosti.buildsystem.object.world.WorldStatus;
 import com.google.common.collect.Sets;
 import org.bukkit.entity.Player;
@@ -23,6 +24,7 @@ public class WorldsInventory extends FilteredWorldsInventory implements Listener
 
     private final BuildSystem plugin;
     private final InventoryManager inventoryManager;
+    private final PlayerManager playerManager;
 
     public WorldsInventory(BuildSystem plugin) {
         super(plugin, "world_navigator_title", "world_navigator_no_worlds", false,
@@ -30,6 +32,7 @@ public class WorldsInventory extends FilteredWorldsInventory implements Listener
 
         this.plugin = plugin;
         this.inventoryManager = plugin.getInventoryManager();
+        this.playerManager = plugin.getPlayerManager();
 
         plugin.getServer().getPluginManager().registerEvents(this, plugin);
     }
@@ -37,7 +40,7 @@ public class WorldsInventory extends FilteredWorldsInventory implements Listener
     @Override
     protected Inventory createInventory(Player player) {
         Inventory inventory = super.createInventory(player);
-        if (super.canCreateWorld(player)) {
+        if (playerManager.canCreateWorld(player, false)) {
             addWorldCreateItem(inventory, player);
         }
         return inventory;

--- a/buildsystem-core/src/main/java/com/eintosti/buildsystem/inventory/WorldsInventory.java
+++ b/buildsystem-core/src/main/java/com/eintosti/buildsystem/inventory/WorldsInventory.java
@@ -44,7 +44,7 @@ public class WorldsInventory extends FilteredWorldsInventory implements Listener
     }
 
     private void addWorldCreateItem(Inventory inventory, Player player) {
-        if (!player.hasPermission("buildsystem.createworld")) {
+        if (!player.hasPermission("buildsystem.create.public")) {
             inventoryManager.addGlassPane(plugin, player, inventory, 49);
             return;
         }

--- a/buildsystem-core/src/main/java/com/eintosti/buildsystem/listener/InventoryCloseListener.java
+++ b/buildsystem-core/src/main/java/com/eintosti/buildsystem/listener/InventoryCloseListener.java
@@ -38,15 +38,6 @@ public class InventoryCloseListener implements Listener {
     }
 
     @EventHandler
-    public void onPrivateInventoryClose(InventoryCloseEvent event) {
-        if (!(event.getPlayer() instanceof Player)) {
-            return;
-        }
-        Player player = (Player) event.getPlayer();
-        worldManager.createPrivateWorldPlayers.remove(player);
-    }
-
-    @EventHandler
     public void onSetupInventoryClose(InventoryCloseEvent event) {
         if (!event.getView().getTitle().equals(plugin.getString("setup_title"))) {
             return;

--- a/buildsystem-core/src/main/java/com/eintosti/buildsystem/manager/InventoryManager.java
+++ b/buildsystem-core/src/main/java/com/eintosti/buildsystem/manager/InventoryManager.java
@@ -405,17 +405,15 @@ public class InventoryManager {
         for (int i = 0; i <= 8; i++) {
             addGlassPane(plugin, player, inventory, i);
         }
-        for (int i = 46; i <= 48; i++) {
-            addGlassPane(plugin, player, inventory, i);
-        }
-        for (int i = 50; i <= 52; i++) {
-            addGlassPane(plugin, player, inventory, i);
-        }
 
         if (numOfPages > 1 && currentPage > 0) {
             addUrlSkull(inventory, 45, plugin.getString("gui_previous_page"), "https://textures.minecraft.net/texture/f7aacad193e2226971ed95302dba433438be4644fbab5ebf818054061667fbe2");
         } else {
             addGlassPane(plugin, player, inventory, 45);
+        }
+
+        for (int i = 46; i <= 52; i++) {
+            addGlassPane(plugin, player, inventory, i);
         }
 
         if (numOfPages > 1 && currentPage < (numOfPages - 1)) {

--- a/buildsystem-core/src/main/java/com/eintosti/buildsystem/manager/PlayerManager.java
+++ b/buildsystem-core/src/main/java/com/eintosti/buildsystem/manager/PlayerManager.java
@@ -118,6 +118,33 @@ public class PlayerManager {
     }
 
     /**
+     * Gets whether the given player is allowed to create a new {@link BuildWorld}.<br>
+     * This depends on the following factors:
+     * <ul>
+     *  <li>Is the maximum amount of worlds set by the config less than the amount of existing worlds?</li>
+     *  <li>Is the maximum amount of worlds created by the player less than the amount of worlds said player is allowed to create?</li>
+     * <ul>
+     *
+     * @param player The player trying to create a world
+     * @return {@code true} if the player is allowed to create a world, otherwise {@code false}
+     */
+    public boolean canCreateWorld(Player player, boolean showPrivateWorlds) {
+        WorldManager worldManager = plugin.getWorldManager();
+
+        int maxWorldAmountConfig = configValues.getMaxWorldAmount(showPrivateWorlds);
+        if (maxWorldAmountConfig >= 0 && worldManager.getBuildWorlds().size() >= maxWorldAmountConfig) {
+            return false;
+        }
+
+        int maxWorldAmountPlayer = getMaxWorlds(player, showPrivateWorlds);
+        if (maxWorldAmountPlayer >= 0 && worldManager.getBuildWorldsCreatedByPlayer(player, showPrivateWorlds).size() >= maxWorldAmountPlayer) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
      * Returns the maximum amount of {@link BuildWorld}s a player can create.<br>
      * If the player has the permission {@code buildsystem.admin}</li>, unlimited worlds can be created.<br>
      * Otherwise, there are two different permissions to set said amount:<br>

--- a/buildsystem-core/src/main/java/com/eintosti/buildsystem/manager/PlayerManager.java
+++ b/buildsystem-core/src/main/java/com/eintosti/buildsystem/manager/PlayerManager.java
@@ -22,6 +22,7 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.permissions.PermissionAttachmentInfo;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.util.Vector;
 import org.jetbrains.annotations.NotNull;
@@ -114,6 +115,60 @@ public class PlayerManager {
 
     public Set<UUID> getBuildPlayers() {
         return buildPlayers;
+    }
+
+    /**
+     * Returns the maximum amount of {@link BuildWorld}s a player can create.<br>
+     * If the player has the permission {@code buildsystem.admin}</li>, unlimited worlds can be created.<br>
+     * Otherwise, there are two different permissions to set said amount:<br>
+     * To set the maximum of...
+     * <ul>
+     *  <li>...public worlds, use {@code buildsystem.create.public.<amount>}</li>
+     *  <li>...private worlds, use {@code buildsystem.create.private.<amount>}</li>
+     * <ul>
+     *
+     * @param player The player object
+     * @return If set, the maximum amount of worlds a player can create, otherwise -1
+     */
+    public int getMaxWorlds(Player player, boolean privateWorld) {
+        int max = -1;
+        if (player.hasPermission("buildsystem.admin")) {
+            return -1;
+        }
+
+        for (PermissionAttachmentInfo permission : player.getEffectivePermissions()) {
+            String permissionString = permission.getPermission();
+            String[] splitPermission = permissionString.split("\\.");
+
+            if (splitPermission.length != 4) {
+                continue;
+            }
+
+            if (!splitPermission[1].equalsIgnoreCase("create")) {
+                continue;
+            }
+
+            String worldVisibility = privateWorld ? "private" : "public";
+            if (!splitPermission[2].equalsIgnoreCase(worldVisibility)) {
+                continue;
+            }
+
+            String amountString = splitPermission[3];
+            if (amountString.equals("*")) {
+                return -1;
+            }
+
+            try {
+                int amount = Integer.parseInt(amountString);
+                if (amount > max) {
+                    max = amount;
+                }
+            } catch (NumberFormatException e) {
+                e.printStackTrace();
+            }
+        }
+
+        return max;
     }
 
     public void forceUpdateSidebar(BuildWorld buildWorld) {

--- a/buildsystem-core/src/main/java/com/eintosti/buildsystem/manager/WorldManager.java
+++ b/buildsystem-core/src/main/java/com/eintosti/buildsystem/manager/WorldManager.java
@@ -51,6 +51,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
+import java.util.stream.Collectors;
 
 /**
  * @author einTosti
@@ -62,7 +63,7 @@ public class WorldManager {
     private final WorldConfig worldConfig;
     private final List<BuildWorld> buildWorlds;
 
-    public HashSet<Player> createPrivateWorldPlayers;
+    public Set<Player> createPrivateWorldPlayers;
 
     public WorldManager(BuildSystem plugin) {
         this.plugin = plugin;
@@ -73,6 +74,12 @@ public class WorldManager {
         this.createPrivateWorldPlayers = new HashSet<>();
     }
 
+    /**
+     * Gets the {@link BuildWorld} by the given name.
+     *
+     * @param worldName The name of the world
+     * @return The world object if one was found, {@code null} otherwise
+     */
     public BuildWorld getBuildWorld(String worldName) {
         return this.buildWorlds.stream()
                 .filter(buildWorld -> buildWorld.getName().equalsIgnoreCase(worldName))
@@ -80,21 +87,73 @@ public class WorldManager {
                 .orElse(null);
     }
 
+    /**
+     * Gets the {@link BuildWorld} by the given {@link World}.
+     *
+     * @param world The bukkit world object
+     * @return The world object if one was found, {@code null} otherwise
+     */
     public BuildWorld getBuildWorld(World world) {
         return getBuildWorld(world.getName());
     }
 
+    /**
+     * Gets a list of all {@link BuildWorld}s.
+     *
+     * @return A list of all worlds
+     */
     public List<BuildWorld> getBuildWorlds() {
         return buildWorlds;
     }
 
     /**
-     * Gets the name of the {@link BuildWorld} the player is trying to create and removes all illegal characters.
+     * Gets a list of all {@link BuildWorld}s created by the given player.
+     *
+     * @param player The player who created the world
+     * @return A list of all worlds created by the given player.
+     */
+    public List<BuildWorld> getBuildWorldsCreatedByPlayer(Player player) {
+        return getBuildWorlds().stream()
+                .filter(buildWorld -> buildWorld.getCreatorId() != null)
+                .filter(buildWorld -> buildWorld.getCreatorId().equals(player.getUniqueId()))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Gets a list of all {@link BuildWorld}s created by the given player.
+     *
+     * @param player The player who created the world
+     * @param privateWorld {@code true} if to return private worlds, otherwise {@code false}
+     * @return A list of all worlds created by the given player.
+     */
+    public List<BuildWorld> getBuildWorldsCreatedByPlayer(Player player, boolean privateWorld) {
+        return getBuildWorldsCreatedByPlayer(player).stream()
+                .filter(buildWorld -> isCorrectVisibility(buildWorld, privateWorld))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Gets if a {@link BuildWorld}'s visibility is equal to the given visibility.
+     *
+     * @param buildWorld The world object
+     * @param privateWorld Should the world's visibility be equal to private?
+     * @return {@code true} if the world's visibility is equal to the given visibility, otherwise {@code false}
+     */
+    public boolean isCorrectVisibility(BuildWorld buildWorld, boolean privateWorld) {
+        if (privateWorld) {
+            return buildWorld.isPrivate();
+        } else {
+            return !buildWorld.isPrivate();
+        }
+    }
+
+    /**
+     * Gets the name (and in doing so removes all illegal characters) of the {@link BuildWorld} the player is trying to create.
      * If the world is going to be a private world, its name will be equal to the player's name.
      *
      * @param player       The player who is creating the world
      * @param worldType    The world type
-     * @param template     The name of the template world, if any, otherwise `null`
+     * @param template     The name of the template world, if any, otherwise {@code null}
      * @param privateWorld Is world going to be a private world?
      */
     public void startWorldNameInput(Player player, WorldType worldType, @Nullable String template, boolean privateWorld) {
@@ -129,7 +188,7 @@ public class WorldManager {
      * @param player       The player who is creating the world
      * @param worldName    The name of the world
      * @param worldType    The world type
-     * @param template     The name of the template world. Only if the world is being created with a template, otherwise ``null
+     * @param template     The name of the template world. Only if the world is being created with a template, otherwise {@code null}
      * @param privateWorld Is world going to be a private world?
      */
     private void manageWorldType(Player player, String worldName, WorldType worldType, @Nullable String template, boolean privateWorld) {
@@ -202,11 +261,12 @@ public class WorldManager {
             return;
         }
 
-        //Get Generator
         new PlayerChatInput(plugin, player, "enter_generator_name", input -> {
-            List<String> genArray = Arrays.asList(input.split(":"));
-            if (genArray.size() < 2) {
-                genArray.add("");
+            List<String> genArray;
+            if (input.contains(":")) {
+                genArray = Arrays.asList(input.split(":"));
+            } else {
+                genArray = Arrays.asList(input, input);
             }
 
             ChunkGenerator chunkGenerator = getChunkGenerator(genArray.get(0), genArray.get(1), worldName);
@@ -345,7 +405,6 @@ public class WorldManager {
         }
 
         World bukkitWorld = Bukkit.createWorld(worldCreator);
-
         if (bukkitWorld != null) {
             bukkitWorld.setDifficulty(configValues.getWorldDifficulty());
             bukkitWorld.setTime(configValues.getNoonTime());
@@ -387,7 +446,10 @@ public class WorldManager {
     public void importWorld(Player player, String worldName, Generator generator, String... generatorName) {
         for (String charString : worldName.split("")) {
             if (charString.matches("[^A-Za-z0-9/_-]")) {
-                player.sendMessage(plugin.getString("worlds_import_invalid_character").replace("%world%", worldName).replace("%char%", charString));
+                player.sendMessage(plugin.getString("worlds_import_invalid_character")
+                        .replace("%world%", worldName)
+                        .replace("%char%", charString)
+                );
                 return;
             }
         }
@@ -495,22 +557,19 @@ public class WorldManager {
             return;
         }
 
-        unimportWorld(buildWorld);
-
-        World bukkitWorld = Bukkit.getWorld(buildWorld.getName());
-        if (bukkitWorld != null) {
-            removePlayersFromWorld(buildWorld.getName(), plugin.getString("worlds_delete_players_world"));
-            Bukkit.getServer().unloadWorld(bukkitWorld, false);
-            Bukkit.getWorlds().remove(bukkitWorld);
+        String worldName = buildWorld.getName();
+        if (Bukkit.getWorld(worldName) != null) {
+            removePlayersFromWorld(worldName, plugin.getString("worlds_delete_players_world"));
+            unimportWorld(buildWorld);
         }
 
-        File deleteFolder = new File(Bukkit.getWorldContainer(), buildWorld.getName());
+        File deleteFolder = new File(Bukkit.getWorldContainer(), worldName);
         if (!deleteFolder.exists()) {
             player.sendMessage(plugin.getString("worlds_delete_unknown_directory"));
             return;
         }
 
-        player.sendMessage(plugin.getString("worlds_delete_started").replace("%world%", buildWorld.getName()));
+        player.sendMessage(plugin.getString("worlds_delete_started").replace("%world%", worldName));
         FileUtils.deleteDirectory(deleteFolder);
         player.sendMessage(plugin.getString("worlds_delete_finished"));
     }

--- a/buildsystem-core/src/main/java/com/eintosti/buildsystem/manager/WorldManager.java
+++ b/buildsystem-core/src/main/java/com/eintosti/buildsystem/manager/WorldManager.java
@@ -61,17 +61,15 @@ public class WorldManager {
     private final BuildSystem plugin;
     private final ConfigValues configValues;
     private final WorldConfig worldConfig;
-    private final List<BuildWorld> buildWorlds;
 
-    public Set<Player> createPrivateWorldPlayers;
+    private final List<BuildWorld> buildWorlds;
 
     public WorldManager(BuildSystem plugin) {
         this.plugin = plugin;
         this.configValues = plugin.getConfigValues();
         this.worldConfig = new WorldConfig(plugin);
-        this.buildWorlds = new ArrayList<>();
 
-        this.createPrivateWorldPlayers = new HashSet<>();
+        this.buildWorlds = new ArrayList<>();
     }
 
     /**
@@ -122,7 +120,7 @@ public class WorldManager {
     /**
      * Gets a list of all {@link BuildWorld}s created by the given player.
      *
-     * @param player The player who created the world
+     * @param player       The player who created the world
      * @param privateWorld {@code true} if to return private worlds, otherwise {@code false}
      * @return A list of all worlds created by the given player.
      */
@@ -135,7 +133,7 @@ public class WorldManager {
     /**
      * Gets if a {@link BuildWorld}'s visibility is equal to the given visibility.
      *
-     * @param buildWorld The world object
+     * @param buildWorld   The world object
      * @param privateWorld Should the world's visibility be equal to private?
      * @return {@code true} if the world's visibility is equal to the given visibility, otherwise {@code false}
      */
@@ -238,12 +236,21 @@ public class WorldManager {
             return;
         }
 
-        BuildWorld buildWorld = new BuildWorld(plugin, worldName, player.getName(), player.getUniqueId(), worldType, System.currentTimeMillis(), privateWorld);
+        BuildWorld buildWorld = new BuildWorld(
+                plugin,
+                worldName,
+                player.getName(),
+                player.getUniqueId(),
+                worldType,
+                System.currentTimeMillis(),
+                privateWorld
+        );
         buildWorlds.add(buildWorld);
 
         player.sendMessage(plugin.getString("worlds_world_creation_started")
-                .replace("%world%", buildWorld.getName())
-                .replace("%type%", buildWorld.getTypeName()));
+                .replace("%world%", worldName)
+                .replace("%type%", buildWorld.getTypeName())
+        );
         finishPreparationsAndGenerate(buildWorld);
         player.sendMessage(plugin.getString("worlds_creation_finished"));
     }

--- a/buildsystem-core/src/main/java/com/eintosti/buildsystem/util/ConfigValues.java
+++ b/buildsystem-core/src/main/java/com/eintosti/buildsystem/util/ConfigValues.java
@@ -56,6 +56,8 @@ public class ConfigValues {
     private int nightTime;
     private int worldBorderSize;
     private int importDelay;
+    private int maxPublicWorldAmount;
+    private int maxPrivateWorldAmount;
 
     private Map<String, String> defaultGameRules;
     private Set<String> blackListedWorldsToUnload;
@@ -116,9 +118,12 @@ public class ConfigValues {
         this.timeUntilUnload = config.getString("world.unload.time-until-unload", "01:00:00");
         this.blackListedWorldsToUnload = new HashSet<>(config.getStringList("world.unload.blacklisted-worlds"));
 
-        this.voidBlock = config.getBoolean("world.void-block", true);
-
         this.importDelay = config.getInt("world.import-all.delay", 30);
+
+        this.maxPublicWorldAmount = config.getInt("world.max-amount.public", -1);
+        this.maxPrivateWorldAmount = config.getInt("world.max-amount.private", -1);
+
+        this.voidBlock = config.getBoolean("world.void-block", true);
     }
 
     public String getDateFormat() {
@@ -231,6 +236,10 @@ public class ConfigValues {
 
     public int getImportDelay() {
         return importDelay;
+    }
+
+    public int getMaxWorldAmount(boolean privateWorld) {
+        return privateWorld ? maxPrivateWorldAmount : maxPublicWorldAmount;
     }
 
     public Map<String, String> getDefaultGameRules() {

--- a/buildsystem-core/src/main/resources/config.yml
+++ b/buildsystem-core/src/main/resources/config.yml
@@ -34,6 +34,11 @@ world:
       block-placement: true
       block-interactions: true
   lock-weather: true
+  import-all:
+    delay: 30
+  max-amount:
+    public: -1
+    private: -1
   unload:
     enabled: false
     time-until-unload: "01:00:00"
@@ -42,5 +47,3 @@ world:
       - world_nether
       - worth_the_end
   void-block: true
-  import-all:
-    delay: 30

--- a/buildsystem-core/src/main/resources/plugin.yml
+++ b/buildsystem-core/src/main/resources/plugin.yml
@@ -70,7 +70,7 @@ permissions:
   buildsystem.gui:
     description: Open the "Worlds-GUI".
     default: true
-  buildsystem.createprivate:
+  buildsystem.create.private:
     description: Create a private world.
     default: true
   buildsystem.physics.message:


### PR DESCRIPTION
> Limits do not apply to admin players with the permission `buildsystem.admin`!

The are two different types of limited introduced with this PR:

**1. Global limits**
Global limits are limits that are set in the `config.yml` and apply to each player equally. If the amount of worlds exceeds the defined limit, then no more worlds can be created.

![Config](https://user-images.githubusercontent.com/29168243/154070101-43991310-1740-42df-a0e0-55f7c180bcbf.png)
> If a limit is set to **-1**, no limit is applied

**2. Local limits**
Local limits are limits that are applied via Permissions. There are two different permission wich set the maximum amount of worlds a player can create:
* `buildsystem.create.public.<amount>` restricts the amount of **public** ...
* `buildsystem.create.private.<amount>` restricts the amount of **private** ...  

... worlds a player can create


**3. Other changes**
* The permission for creating **public** worlds has been changed to `buildsystem.create.public`
* The permission for creating **private** worlds has been changed to `buildsystem.create.private`