### PR TITLE
Implement teleportation to world after its creation

### DIFF
--- a/buildsystem-core/src/main/java/com/eintosti/buildsystem/manager/WorldManager.java
+++ b/buildsystem-core/src/main/java/com/eintosti/buildsystem/manager/WorldManager.java
@@ -43,7 +43,6 @@ import org.jetbrains.annotations.Nullable;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -183,6 +182,7 @@ public class WorldManager {
 
     /**
      * Depending on the {@link BuildWorld}'s {@link WorldType}, the corresponding {@link World} will be generated in a different way.
+     * Then, if the creation of the world was successful and the config is set accordingly, the player is teleported to the world.
      *
      * @param player       The player who is creating the world
      * @param worldName    The name of the world
@@ -193,14 +193,28 @@ public class WorldManager {
     private void manageWorldType(Player player, String worldName, WorldType worldType, @Nullable String template, boolean privateWorld) {
         switch (worldType) {
             default:
-                createWorld(player, worldName, worldType, privateWorld);
+                if (!createWorld(player, worldName, worldType, privateWorld)) {
+                    return;
+                }
                 break;
             case CUSTOM:
-                createCustomWorld(player, worldName, privateWorld);
+                if (!createCustomWorld(player, worldName, privateWorld)) {
+                    return;
+                }
                 break;
             case TEMPLATE:
-                createTemplateWorld(player, worldName, ChatColor.stripColor(template), privateWorld);
+                if (!createTemplateWorld(player, worldName, ChatColor.stripColor(template), privateWorld)) {
+                    return;
+                }
                 break;
+        }
+
+        if (configValues.isTeleportAfterCreation()) {
+            BuildWorld buildWorld = getBuildWorld(worldName);
+            if (buildWorld == null) {
+                return;
+            }
+            teleport(player, buildWorld);
         }
     }
 
@@ -231,10 +245,11 @@ public class WorldManager {
      * @param worldName    The name of the world
      * @param worldType    The world type
      * @param privateWorld Is world going to be a private world?
+     * @return {@code true} if the world was successfully created, {@code false otherwise}
      */
-    public void createWorld(Player player, String worldName, WorldType worldType, boolean privateWorld) {
+    public boolean createWorld(Player player, String worldName, WorldType worldType, boolean privateWorld) {
         if (worldExists(player, worldName)) {
-            return;
+            return false;
         }
 
         BuildWorld buildWorld = new BuildWorld(
@@ -254,6 +269,7 @@ public class WorldManager {
         );
         finishPreparationsAndGenerate(buildWorld);
         player.sendMessage(plugin.getString("worlds_creation_finished"));
+        return true;
     }
 
     /**
@@ -262,11 +278,12 @@ public class WorldManager {
      * @param player       The player who is creating the world
      * @param worldName    The name of the world
      * @param privateWorld Is world going to be a private world?
+     * @return {@code true} if the world was successfully created, {@code false otherwise}
      * @author Ein_Jojo
      */
-    public void createCustomWorld(Player player, String worldName, boolean privateWorld) {
+    public boolean createCustomWorld(Player player, String worldName, boolean privateWorld) {
         if (worldExists(player, worldName)) {
-            return;
+            return false;
         }
 
         new PlayerChatInput(plugin, player, "enter_generator_name", input -> {
@@ -295,6 +312,7 @@ public class WorldManager {
             generateBukkitWorld(worldName, buildWorld.getType(), chunkGenerator);
             player.sendMessage(plugin.getString("worlds_creation_finished"));
         });
+        return true;
     }
 
     /**
@@ -304,19 +322,20 @@ public class WorldManager {
      * @param worldName    The name of the world
      * @param template     The name of the template world
      * @param privateWorld Is world going to be a private world?
+     * @return {@code true} if the world was successfully created, {@code false otherwise}
      */
-    private void createTemplateWorld(Player player, String worldName, String template, boolean privateWorld) {
+    private boolean createTemplateWorld(Player player, String worldName, String template, boolean privateWorld) {
         boolean worldExists = getBuildWorld(worldName) != null;
         File worldFile = new File(Bukkit.getWorldContainer(), worldName);
         if (worldExists || worldFile.exists()) {
             player.sendMessage(plugin.getString("worlds_world_exists"));
-            return;
+            return false;
         }
 
         File templateFile = new File(plugin.getDataFolder() + File.separator + "templates" + File.separator + template);
         if (!templateFile.exists()) {
             player.sendMessage(plugin.getString("worlds_template_does_not_exist"));
-            return;
+            return false;
         }
 
         BuildWorld buildWorld = new BuildWorld(plugin, worldName, player.getName(), player.getUniqueId(), WorldType.TEMPLATE, System.currentTimeMillis(), privateWorld);
@@ -330,6 +349,7 @@ public class WorldManager {
                 .type(org.bukkit.WorldType.FLAT)
                 .generateStructures(false));
         player.sendMessage(plugin.getString("worlds_creation_finished"));
+        return true;
     }
 
     /**
@@ -377,7 +397,8 @@ public class WorldManager {
                     worldCreator.generator(new ChunkGenerator() {
                         @Override
                         @SuppressWarnings("deprecation")
-                        public @NotNull ChunkData generateChunkData(@NotNull World world, @NotNull Random random, int x, int z, @NotNull BiomeGrid biome) {
+                        public @NotNull
+                        ChunkData generateChunkData(@NotNull World world, @NotNull Random random, int x, int z, @NotNull BiomeGrid biome) {
                             return createChunkData(world);
                         }
                     });
@@ -483,15 +504,22 @@ public class WorldManager {
         }
 
         player.sendMessage(plugin.getString("worlds_import_started").replace("%world%", worldName));
-        buildWorlds.add(new BuildWorld(plugin, worldName, "-", null, WorldType.IMPORTED, FileUtils.getDirectoryCreation(file), false));
-
-        if (chunkGenerator == null) {
-            generateBukkitWorld(worldName, generator.getWorldType());
-        } else {
-            generateBukkitWorld(worldName, generator.getWorldType(), chunkGenerator);
-        }
-
+        BuildWorld buildWorld = new BuildWorld(
+                plugin,
+                worldName,
+                "-",
+                null,
+                WorldType.IMPORTED,
+                FileUtils.getDirectoryCreation(file),
+                false
+        );
+        buildWorlds.add(buildWorld);
+        generateBukkitWorld(worldName, generator.getWorldType(), chunkGenerator);
         player.sendMessage(plugin.getString("worlds_import_finished"));
+
+        if (configValues.isTeleportAfterCreation()) {
+            teleport(player, buildWorld);
+        }
     }
 
     /**

--- a/buildsystem-core/src/main/java/com/eintosti/buildsystem/util/ConfigValues.java
+++ b/buildsystem-core/src/main/java/com/eintosti/buildsystem/util/ConfigValues.java
@@ -37,6 +37,7 @@ public class ConfigValues {
     private boolean scoreboard;
     private boolean spawnTeleportMessage;
     private boolean joinQuitMessages;
+    private boolean teleportAfterCreation;
     private boolean lockWeather;
     private boolean unloadWorlds;
     private boolean voidBlock;
@@ -79,6 +80,7 @@ public class ConfigValues {
         this.updateChecker = config.getBoolean("settings.update-checker", true);
         this.scoreboard = config.getBoolean("settings.scoreboard", true);
         this.archiveVanish = config.getBoolean("settings.archive-vanish", true);
+        this.teleportAfterCreation = config.getBoolean("settings.teleport-after-creation", true);
 
         this.blockWorldEditNonBuilder = config.getBoolean("settings.builder.block-worldedit-non-builder", true);
         this.worldEditWand = XMaterial.valueOf(config.getString("settings.builder.world-edit-wand", "WOODEN_AXE"));
@@ -144,6 +146,10 @@ public class ConfigValues {
 
     public boolean isArchiveVanish() {
         return archiveVanish;
+    }
+
+    public boolean isTeleportAfterCreation() {
+        return teleportAfterCreation;
     }
 
     public boolean isScoreboard() {

--- a/buildsystem-core/src/main/resources/config.yml
+++ b/buildsystem-core/src/main/resources/config.yml
@@ -6,6 +6,7 @@ settings:
   update-checker: true
   scoreboard: true
   archive-vanish: true
+  teleport-after-creation: true
   builder:
     block-worldedit-non-builder: true
     world-edit-wand: "WOODEN_AXE"


### PR DESCRIPTION
Adds a new config option: `teleport-after-creation` (default: `true`)
When enabled, the player is teleported a world after it is created instead of having to enter through the navigator