### PR TITLE
Legacy bug fix with slab breaking

### DIFF
--- a/buildsystem-abstraction/adapter-1_12/src/main/java/com/eintosti/buildsystem/version/v1_12_R1/CustomBlocks_1_12_R1.java
+++ b/buildsystem-abstraction/adapter-1_12/src/main/java/com/eintosti/buildsystem/version/v1_12_R1/CustomBlocks_1_12_R1.java
@@ -204,7 +204,7 @@ public class CustomBlocks_1_12_R1 extends DirectionUtils implements CustomBlocks
                 changedMaterial = Material.STONE_SLAB2;
                 break;
             default:
-                if (changedMaterial != null) {
+                if (changedMaterial == null) {
                     return;
                 }
                 break;

--- a/buildsystem-core/src/main/java/com/eintosti/buildsystem/inventory/SettingsInventory.java
+++ b/buildsystem-core/src/main/java/com/eintosti/buildsystem/inventory/SettingsInventory.java
@@ -96,13 +96,11 @@ public class SettingsInventory implements Listener {
         ItemStack itemStack = material.parseItem();
         ItemMeta itemMeta = itemStack.getItemMeta();
 
-        if (itemMeta != null) {
-            itemMeta.setDisplayName(displayName);
-            itemMeta.setLore(lore);
-            itemMeta.addItemFlags(ItemFlag.values());
-        }
-
+        itemMeta.setDisplayName(displayName);
+        itemMeta.setLore(lore);
+        itemMeta.addItemFlags(ItemFlag.values());
         itemStack.setItemMeta(itemMeta);
+
         if (enabled) {
             itemStack.addUnsafeEnchantment(Enchantment.DURABILITY, 1);
         }
@@ -120,10 +118,8 @@ public class SettingsInventory implements Listener {
         ItemStack itemStack = inventoryManager.getItemStack(inventoryManager.getColouredGlass(plugin, player), plugin.getString("settings_change_design_item"));
         ItemMeta itemMeta = itemStack.getItemMeta();
 
-        if (itemMeta != null) {
-            itemMeta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
-            itemMeta.setLore(plugin.getStringList("settings_change_design_lore"));
-        }
+        itemMeta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
+        itemMeta.setLore(plugin.getStringList("settings_change_design_lore"));
         itemStack.setItemMeta(itemMeta);
         itemStack.addUnsafeEnchantment(Enchantment.DURABILITY, 1);
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.eintosti
-version=2.18.3
+version=2.18.4
 org.gradle.daemon=true
 org.gradle.caching=true
 org.gradle.parallel=true


### PR DESCRIPTION
Fix an error in legacy versions (< 1.13) where normal blocks could not be broken when slab breaking was enabled

Signed-off-by: Thomas Meaney <thomas.meaney@icloud.com>