### PR TITLE
Bug fixes and improvements

### DIFF
--- a/buildsystem-core/src/main/java/com/eintosti/buildsystem/command/WorldsCommand.java
+++ b/buildsystem-core/src/main/java/com/eintosti/buildsystem/command/WorldsCommand.java
@@ -138,6 +138,11 @@ public class WorldsCommand implements CommandExecutor {
                         return true;
                     }
 
+                    if (!buildWorld.isCreator(player) && !player.hasPermission("buildsystem.admin")) {
+                        player.sendMessage(plugin.getString("worlds_delete_not_creator"));
+                        return true;
+                    }
+
                     playerManager.getSelectedWorld().put(player.getUniqueId(), buildWorld);
                     plugin.getDeleteInventory().openInventory(player, buildWorld);
                 } else {
@@ -217,28 +222,12 @@ public class WorldsCommand implements CommandExecutor {
                         }
 
                         Generator generator;
-                        boolean customGenerator = false;
-                        switch (args[3].toLowerCase()) {
-                            case "normal":
-                                generator = Generator.NORMAL;
-                                break;
-                            case "flat":
-                                generator = Generator.FLAT;
-                                break;
-                            case "void":
-                                generator = Generator.VOID;
-                                break;
-                            default:
-                                generator = Generator.CUSTOM;
-                                customGenerator = true;
-                                break;
+                        try {
+                            generator = Generator.valueOf(args[3].toUpperCase());
+                        } catch (IllegalArgumentException e) {
+                            generator = Generator.CUSTOM;
                         }
-
-                        if (!customGenerator) {
-                            worldManager.importWorld(player, args[1], generator);
-                        } else {
-                            worldManager.importWorld(player, args[1], generator, args[3]);
-                        }
+                        worldManager.importWorld(player, args[1], generator, args[3]);
                     } else {
                         player.sendMessage(plugin.getString("worlds_import_usage"));
                     }
@@ -714,7 +703,7 @@ public class WorldsCommand implements CommandExecutor {
                 builderId = builderPlayer.getUniqueId();
             }
 
-            if (buildWorld.isCreator(player)) {
+            if (builderId.equals(player.getUniqueId()) && buildWorld.isCreator(player)) {
                 player.sendMessage(plugin.getString("worlds_addbuilder_already_creator"));
                 player.closeInventory();
                 return;

--- a/buildsystem-core/src/main/java/com/eintosti/buildsystem/inventory/PrivateInventory.java
+++ b/buildsystem-core/src/main/java/com/eintosti/buildsystem/inventory/PrivateInventory.java
@@ -11,8 +11,6 @@ package com.eintosti.buildsystem.inventory;
 import com.eintosti.buildsystem.BuildSystem;
 import com.eintosti.buildsystem.manager.InventoryManager;
 import com.eintosti.buildsystem.manager.PlayerManager;
-import com.eintosti.buildsystem.manager.WorldManager;
-import com.eintosti.buildsystem.object.world.BuildWorld;
 import com.eintosti.buildsystem.object.world.data.WorldStatus;
 import com.google.common.collect.Sets;
 import org.bukkit.entity.Player;
@@ -26,7 +24,6 @@ public class PrivateInventory extends FilteredWorldsInventory {
     private final BuildSystem plugin;
     private final InventoryManager inventoryManager;
     private final PlayerManager playerManager;
-    private final WorldManager worldManager;
 
     public PrivateInventory(BuildSystem plugin) {
         super(plugin, "private_title", "private_no_worlds", true,
@@ -35,7 +32,6 @@ public class PrivateInventory extends FilteredWorldsInventory {
         this.plugin = plugin;
         this.inventoryManager = plugin.getInventoryManager();
         this.playerManager = plugin.getPlayerManager();
-        this.worldManager = plugin.getWorldManager();
     }
 
     @Override
@@ -48,11 +44,10 @@ public class PrivateInventory extends FilteredWorldsInventory {
     }
 
     private void addWorldCreateItem(Inventory inventory, Player player) {
-        BuildWorld buildWorld = worldManager.getBuildWorld(player.getName());
-        if (buildWorld != null || !player.hasPermission("buildsystem.create.private")) {
+        if (player.hasPermission("buildsystem.create.private")) {
+            inventoryManager.addUrlSkull(inventory, 49, plugin.getString("private_create_world"), "https://textures.minecraft.net/texture/3edd20be93520949e6ce789dc4f43efaeb28c717ee6bfcbbe02780142f716");
+        } else {
             inventoryManager.addGlassPane(plugin, player, inventory, 49);
-            return;
         }
-        inventoryManager.addUrlSkull(inventory, 49, plugin.getString("private_create_world"), "https://textures.minecraft.net/texture/3edd20be93520949e6ce789dc4f43efaeb28c717ee6bfcbbe02780142f716");
     }
 }

--- a/buildsystem-core/src/main/java/com/eintosti/buildsystem/manager/InventoryManager.java
+++ b/buildsystem-core/src/main/java/com/eintosti/buildsystem/manager/InventoryManager.java
@@ -379,6 +379,7 @@ public class InventoryManager {
     private List<String> getLore(Player player, BuildWorld buildWorld) {
         List<String> messageList = player.hasPermission("buildsystem.edit") ? plugin.getStringList("world_item_lore_edit") : plugin.getStringList("world_item_lore_normal");
         List<String> lore = new ArrayList<>();
+
         for (String line : messageList) {
             String replace = line
                     .replace("%project%", buildWorld.getProject())
@@ -410,6 +411,7 @@ public class InventoryManager {
                 lore.add(builderString);
             }
         }
+
         return lore;
     }
 

--- a/buildsystem-core/src/main/java/com/eintosti/buildsystem/manager/PlayerManager.java
+++ b/buildsystem-core/src/main/java/com/eintosti/buildsystem/manager/PlayerManager.java
@@ -161,7 +161,7 @@ public class PlayerManager {
     public int getMaxWorlds(Player player, boolean privateWorld) {
         int max = -1;
         if (player.hasPermission("buildsystem.admin")) {
-            return -1;
+            return max;
         }
 
         for (PermissionAttachmentInfo permission : player.getEffectivePermissions()) {

--- a/buildsystem-core/src/main/java/com/eintosti/buildsystem/util/Messages.java
+++ b/buildsystem-core/src/main/java/com/eintosti/buildsystem/util/Messages.java
@@ -234,6 +234,7 @@ public class Messages {
         setMessage(sb, config, "worlds_delete_usage", "%prefix% &7Usage: &b/worlds delete <world>");
         setMessage(sb, config, "worlds_delete_unknown_world", "%prefix% &cUnknown world.");
         setMessage(sb, config, "worlds_delete_unknown_directory", "%prefix% &cError while deleting world: Directory not found!");
+        setMessage(sb, config, "worlds_delete_not_creator", "%prefix% &cYou are not the creator of this world.");
         setMessage(sb, config, "worlds_delete_error", "%prefix% &cError while deleting world: Please try again!");
         setMessage(sb, config, "worlds_delete_canceled", "%prefix% &7The deletion of &b%world% &7was canceled.");
         setMessage(sb, config, "worlds_delete_started", "%prefix% &7The deletion of &b%world% &7has started...");

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.eintosti
-version=2.18.7
+version=2.18.8
 org.gradle.daemon=true
 org.gradle.caching=true
 org.gradle.parallel=true


### PR DESCRIPTION
* Fixes a bug where creators could not add builders to their world with `/worlds addBuilder`
* From now on, only the creator of a world can delete it (or players with the admin permission: `buildsystem.admin`)
* Players are no longer limited to one private world. Use the permission `buildsystem.create.private.<amount>` to the maximum amount a player can create

Signed-off-by: Thomas Meaney <thomas.meaney@icloud.com>